### PR TITLE
revert-103: Revert "OSOE-430: Use get-cwd and don't resolve symlink path"

### DIFF
--- a/Lombiq.VueJs/Assets/Scripts/helpers/process-helpers.js
+++ b/Lombiq.VueJs/Assets/Scripts/helpers/process-helpers.js
@@ -1,6 +1,5 @@
-const fs = require('fs');
-const getProjectDirectory = require('.nx/scripts/get-project-directory');
-const { handleErrorObject, handleErrorMessage, handleWarningMessage } = require('.nx/scripts/handle-error');
+const { handleErrorObject, handleErrorMessage } = require('.nx/scripts/handle-error');
+const path = require('path');
 
 async function executeFunctionByCommandLineArgument(functions) {
     const [functionName, argumentOptionsJson] = process.argv.slice(2);
@@ -34,19 +33,11 @@ async function executeFunctionByCommandLineArgument(functions) {
 }
 
 function leaveNodeModule() {
-    const projectDirectory = getProjectDirectory();
+    const location = process.cwd().split(path.sep).slice(-2).join('/');
 
-    if (!projectDirectory) {
-        handleWarningMessage(
-            'The project directory is not specified. Your environment may be misconfigured, see ' +
-            'get-project-directory for information about what the script is looking for.');
-    }
-    else if (fs.existsSync(projectDirectory)) {
-        process.chdir(projectDirectory);
-    }
-    else {
-        handleWarningMessage(
-            `The project directory according to get-project-directory.js (${projectDirectory}) is not found.`);
+    // Need to check both because Windows and Linux resolve the directory symlink between the two differently.
+    if (location === 'node_modules/lombiq-vuejs' || location === 'node_modules/.lv') {
+        process.chdir(path.resolve('..', '..'));
     }
 }
 

--- a/Lombiq.VueJs/Assets/Scripts/helpers/vue-sfc-compiler-pipeline.js
+++ b/Lombiq.VueJs/Assets/Scripts/helpers/vue-sfc-compiler-pipeline.js
@@ -16,8 +16,8 @@ const { executeFunctionByCommandLineArgument, leaveNodeModule } = require('./pro
 leaveNodeModule();
 
 const defaultOptions = {
-    sfcRootPath: path.join('Assets', 'Scripts', 'VueComponents'),
-    sfcDestinationPath: path.join('wwwroot', 'vue'),
+    sfcRootPath: path.resolve('Assets', 'Scripts', 'VueComponents'),
+    sfcDestinationPath: path.resolve('wwwroot', 'vue'),
     vueJsNodeModulesPath: path.resolve(__dirname, '..', '..', '..', 'node_modules'),
     rollupAlias: {},
     isProduction: false,


### PR DESCRIPTION
[revert-103](https://lombiq.atlassian.net/browse/revert-103)
Reverts Lombiq/Orchard-Vue.js#103