### PR TITLE
OFFI-92: Building scripts

### DIFF
--- a/Lombiq.VueJs/package.json
+++ b/Lombiq.VueJs/package.json
@@ -44,6 +44,10 @@
         "target": "wwwroot/vendors/vue",
         "pattern": "vue.esm-browser.*"
       }
-    ]
+    ],
+    "scripts": {
+      "source": "Assets/Scripts",
+      "target": "wwwroot/js"
+    }
   }
 }


### PR DESCRIPTION
...to fix `vue-component-app.mjs` not being embedded into the DLL.

[OFFI-92](https://lombiq.atlassian.net/browse/OFFI-92)

[OFFI-92]: https://lombiq.atlassian.net/browse/OFFI-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ