### PR TITLE
OSOE-815: Workaround for random \"Error in styles pipeline: linting failed.\" during Windows builds

### DIFF
--- a/Lombiq.VueJs/package.json
+++ b/Lombiq.VueJs/package.json
@@ -50,6 +50,10 @@
     "scripts": {
       "source": "Assets/Scripts",
       "target": "wwwroot/js"
+    },
+    "styles": {
+      "source": "Assets/Styles",
+      "target": "wwwroot/css"
     }
   }
 }


### PR DESCRIPTION
[OSOE-815](https://lombiq.atlassian.net/browse/OSOE-815)
Also see https://github.com/Lombiq/Orchard-Vue.js/issues/162.

[OSOE-815]: https://lombiq.atlassian.net/browse/OSOE-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ