### PR TITLE
OSOE-1115: Update SixLabors.ImageSharp to 3.1.8

### DIFF
--- a/Lombiq.VueJs.Samples/Lombiq.VueJs.Samples.csproj
+++ b/Lombiq.VueJs.Samples/Lombiq.VueJs.Samples.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="OrchardCore.DisplayManagement" Version="2.1.0" />
     <PackageReference Include="OrchardCore.ResourceManagement" Version="2.1.0" />
     <!-- Only needed to override the vulnerable version referenced by ZXing.Net.Bindings.ImageSharp.V3. -->
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.8" />
     <PackageReference Include="ZXing.Net.Bindings.ImageSharp.V3" Version="0.16.16" />
   </ItemGroup>
 


### PR DESCRIPTION
[OSOE-1115](https://lombiq.atlassian.net/browse/OSOE-1115)

[OSOE-1115]: https://lombiq.atlassian.net/browse/OSOE-1115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ